### PR TITLE
Enable Audio and System control keys

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -1,1 +1,3 @@
 SRC += source.c
+
+EXTRAKEY_ENABLE = yes # Enable Audio and System control keys


### PR DESCRIPTION
To fix vol up/down, see https://docs.qmk.fm/#/faq_misc?id=special-extra-key-doesnt-work-system-audio-control-keys